### PR TITLE
Store indices in Neo4j, create relations to cities

### DIFF
--- a/urbansearch/utils/db_utils.py
+++ b/urbansearch/utils/db_utils.py
@@ -1,7 +1,7 @@
 import logging
 import math
 
-from neo4j.v1 import GraphDatabase, basic_auth
+from neo4j.v1 import GraphDatabase, basic_auth, SessionError, CypherSyntaxError
 
 import config
 
@@ -48,6 +48,23 @@ def _city_property(city, property_name):
         return float(city['a'].properties[property_name])
     except ValueError:
         return city['a'].properties[property_name]
+
+
+def perform_query(query):
+    """
+    Utility method to run an arbitrary query.
+
+    Use with caution!
+
+    :param query: The query to execute
+    :return: The result of the query, as provided by Neo4j
+    """
+    try:
+        with _get_session() as session:
+            return [r for r in session.run(query)]
+    except (CypherSyntaxError, SessionError) as e:
+        logger.error('query: %s\nraised error: %s' % (query, e))
+        return None
 
 
 def city_names():


### PR DESCRIPTION
When an index has been marked as relevant, it needs to be stored in Neo4j and connected to the cities that occur within the document it links to.

This branch provides such functionality and aims to construct a query such as the following:

```
MATCH (c0:City { name: "Hengelo" })
MATCH (c1:City { name: "Deventer" })
MERGE (i:Index:Economy { filename: "a.gz", offset: 10, length: 12 })
CREATE UNIQUE (c0)-[r0:OCCURS_IN]->(i), (c1)-[r1:OCCURS_IN]->(i)
RETURN ID(c0) AS id0, ID(c1) AS id1
```

It creates a node labeled Index and, if provided, extracted categories. Additionally, for every city mentioned in the document, it creates a relation to the index to be able to quickly retrieve the set of documents in which a city is mentioned.