### PR TITLE
Add score storage & updating

### DIFF
--- a/tests/utils/test_db_utils.py
+++ b/tests/utils/test_db_utils.py
@@ -24,14 +24,21 @@ from urbansearch.utils import db_utils
 # database. Travis has it's own database, containing only what is mentioned above.
 
 @pytest.fixture
-def clean_neo4j(request):
+def clean_neo4j_index(request):
     # Cleans all created relations to index named 'test.gz'
     def clean():
-        print('Cleaning database...')
         db_utils.perform_query('MATCH ()-[r]->(n:Index {filename: "test.gz"}) DELETE r, n')
-        print('Done!')
 
     request.addfinalizer(clean)
+
+
+@pytest.fixture
+def clean_neo4j_ic_rel(request):
+    # Cleans all created relations labeled REL_TEST
+    def clean_ic_rel():
+        db_utils.perform_query('MATCH ()-[r:REL_TEST]->() DELETE r')
+
+    request.addfinalizer(clean_ic_rel)
 
 
 def test_caching():
@@ -91,7 +98,7 @@ def test_invalid_query():
     assert db_utils.perform_query('MATCH (n:City)') is None
 
 
-@pytest.mark.usefixtures('clean_neo4j')
+@pytest.mark.usefixtures('clean_neo4j_index')
 def test_store_single_cooccurrence():
     index = {'filename': 'test.gz', 'length': 10, 'offset': 12}
     co_occurrences = [('Amsterdam', 'Rotterdam')]
@@ -99,14 +106,14 @@ def test_store_single_cooccurrence():
     assert db_utils.store_index(index=index, co_occurrences=co_occurrences, topics=topics)
 
 
-@pytest.mark.usefixtures('clean_neo4j')
+@pytest.mark.usefixtures('clean_neo4j_index')
 def test_store_single_cooccurrence_no_topic():
     index = {'filename': 'test.gz', 'length': 10, 'offset': 12}
     co_occurrences = [('Amsterdam', 'Rotterdam')]
     assert db_utils.store_index(index=index, co_occurrences=co_occurrences)
 
 
-@pytest.mark.usefixtures('clean_neo4j')
+@pytest.mark.usefixtures('clean_neo4j_index')
 def test_store_multi_cooccurrence():
     index = {'filename': 'test.gz', 'length': 10, 'offset': 12}
     co_occurrences = [('Amsterdam', 'Rotterdam'), ('Amsterdam', 'Appingedam'), ('Rotterdam', 'Appingedam')]
@@ -114,8 +121,104 @@ def test_store_multi_cooccurrence():
     assert db_utils.store_index(index=index, co_occurrences=co_occurrences, topics=topics)
 
 
-@pytest.mark.usefixtures('clean_neo4j')
+@pytest.mark.usefixtures('clean_neo4j_index')
 def test_store_multi_cooccurrences_no_topic():
     index = {'filename': 'test.gz', 'length': 10, 'offset': 12}
     co_occurrences = [('Amsterdam', 'Rotterdam'), ('Amsterdam', 'Appingedam'), ('Rotterdam', 'Appingedam')]
     assert db_utils.store_index(index=index, co_occurrences=co_occurrences)
+
+
+@pytest.mark.usefixtures('clean_neo4j_ic_rel')
+def test_store_intercity_relation_default():
+    assert db_utils.store_ic_rel('Amsterdam', 'Rotterdam', rel_name='REL_TEST')
+
+
+def test_get_instercity_relation_none():
+    assert db_utils.get_ic_rel('Rotterdam', 'Amsterdam', rel_name='REL_TEST') is None
+
+
+@pytest.mark.usefixtures('clean_neo4j_ic_rel')
+def test_get_instercity_relation():
+    expected = {
+        'commuting': 0,
+        'shopping': 1,
+        'leisure': 0,
+        'moving': 1,
+        'business': 0,
+        'education': 1,
+        'collaboration': 0,
+        'transportation': 1,
+        'other': 0
+    }
+    db_utils.store_ic_rel('Rotterdam', 'Amsterdam', scores=expected, rel_name='REL_TEST')
+    assert db_utils.get_ic_rel('Rotterdam', 'Amsterdam', rel_name='REL_TEST') == expected
+
+
+@pytest.mark.usefixtures('clean_neo4j_ic_rel')
+def test_store_intercity_relation_full():
+    scores = {
+        'commuting': 0.5,
+        'shopping': 0.13,
+        'leisure': 0.12,
+        'moving': 0.11,
+        'business': 0.14,
+        'education': 0.15,
+        'collaboration': 0.16,
+        'transportation': 0.17,
+        'other': 0.19
+    }
+    assert db_utils.store_ic_rel('Amsterdam', 'Rotterdam', scores=scores, rel_name='REL_TEST')
+    assert db_utils.get_ic_rel('Amsterdam', 'Rotterdam', rel_name='REL_TEST') == scores
+
+
+@pytest.mark.usefixtures('clean_neo4j_ic_rel')
+def test_store_intercity_relation_partial():
+    scores = {
+        'commuting': 0.5,
+        'shopping': 0.13,
+        'leisure': 0.12,
+        'moving': 0.11
+    }
+    expected = {
+        'commuting': 0.5,
+        'shopping': 0.13,
+        'leisure': 0.12,
+        'moving': 0.11,
+        'business': -1,
+        'education': -1,
+        'collaboration': -1,
+        'transportation': -1,
+        'other': -1
+    }
+    assert db_utils.store_ic_rel('Amsterdam', 'Rotterdam', scores=scores, rel_name='REL_TEST')
+    assert db_utils.get_ic_rel('Amsterdam', 'Rotterdam', rel_name='REL_TEST') == expected
+
+
+@pytest.mark.usefixtures('clean_neo4j_ic_rel')
+def test_store_intercity_relation_with_update():
+    scores = {
+        'commuting': 0.5,
+        'shopping': 0.13,
+        'leisure': 0.12,
+        'moving': 0.11
+    }
+    update = {'commuting': 0.6}
+    expected = {
+        'commuting': 0.6,
+        'shopping': 0.13,
+        'leisure': 0.12,
+        'moving': 0.11,
+        'business': -1,
+        'education': -1,
+        'collaboration': -1,
+        'transportation': -1,
+        'other': -1
+    }
+    assert db_utils.store_ic_rel('Amsterdam', 'Rotterdam', scores=scores, rel_name='REL_TEST')
+    assert db_utils.store_ic_rel('Amsterdam', 'Rotterdam', scores=update, rel_name='REL_TEST')
+    assert db_utils.get_ic_rel('Amsterdam', 'Rotterdam', rel_name='REL_TEST') == expected
+
+
+def test_store_intercity_relation_invalid():
+    with pytest.raises(ValueError):
+        db_utils.store_ic_rel('Amsterdam', 'Rotterdam', scores={'wrong': 1}, rel_name='REL_TEST')


### PR DESCRIPTION
Stores and updates intercity relation scores in neo4j using dictionaries of category:score pairs.

Fully tested so should be ready to merge after processing possible comments