### PR TITLE
Memory footprint reduced when using parallel computation

### DIFF
--- a/tests/gathering/test_gathering.py
+++ b/tests/gathering/test_gathering.py
@@ -138,3 +138,28 @@ def test_opt_workers():
     index2 = queue.get_nowait()
     assert index is not None
     assert index2 is not None
+
+
+def test_remove_keys_empty():
+    d = {}
+    assert pd._remove_keys(d) == d
+
+
+def test_remove_key():
+    d = {'Ajax': 'Kampioen'}
+    assert pd._remove_keys(d) == {}
+
+
+def test_remove_keys():
+    d = {'Ajax': 'Kampioen',
+         'length': '1',
+         'offset': '2',
+         'Feyenoord': 'Niet',
+         'filename': 'henk'
+         }
+
+    exp = {'length': '1',
+           'offset': '2',
+           'filename': 'henk'
+           }
+    assert pd._remove_keys(d) == exp

--- a/tests/gathering/test_gathering.py
+++ b/tests/gathering/test_gathering.py
@@ -102,7 +102,7 @@ def test_index_to_txt():
     assert result == exp
 
 
-def test_run_worker():
+def test_run_worker_gz():
     man = Manager()
     queue = man.Queue()
     directory = os.path.join(config.get('resources', 'test'), 'indices_dir/')
@@ -113,6 +113,18 @@ def test_run_worker():
     assert index is not None
     # Order is unknown, so allow both possibilities
     assert int(index['offset']) in [727926652, 808]
+
+
+def test_run_worker():
+    man = Manager()
+    queue = man.Queue()
+    directory = os.path.join(config.get('resources', 'test'), 'indices_dir/')
+    files = [_file.path for _file in os.scandir(directory)
+             if _file.is_file() and not _file.path.endswith('.gz')]
+    pd.worker(queue, files, False)
+    index = queue.get_nowait()
+    assert index is not None
+    assert int(index['offset']) == 727926652
 
 
 def test_run_2_workers():

--- a/tests/gathering/test_indices_selector.py
+++ b/tests/gathering/test_indices_selector.py
@@ -33,7 +33,8 @@ def test_relevant_indices_from_dir():
     directory = os.path.join(config.get('resources', 'test'), 'indices_dir/')
     relevant = ind_sel.relevant_indices_from_dir(directory)
     assert len(relevant) == 2
-    assert relevant[0]['digest'] == 'WPTH3FM5VR7UGLA5PZS5L5YI22TNIKXG'
+    # Order doesn't matter
+    assert int(relevant[0]['offset']) in [727926652, 808]
 
 
 def test_run_worker():
@@ -46,8 +47,8 @@ def test_run_worker():
     ind_sel.worker(queue, files)
     index = queue.get_nowait()
     assert index is not None
-    assert int(index['status']) == 200
-    assert index['digest'] == 'WPTH3FM5VR7UGLA5PZS5L5YI22TNIKXG'
+    # Order doesn't matter
+    assert int(index['offset']) in [727926652, 808]
 
 
 def test_run_2_workers():

--- a/tests/gathering/test_indices_selector.py
+++ b/tests/gathering/test_indices_selector.py
@@ -60,9 +60,10 @@ def test_run_2_workers():
     index2 = queue.get_nowait()
     assert index is not None
     assert index2 is not None
-    assert int(index['status']) == 200
-    assert index['digest'] == 'WPTH3FM5VR7UGLA5PZS5L5YI22TNIKXG'
-    assert index2['digest'] == 'WPTH3FM5VR7UGLA5PZS5L5YI22TNIKXG'
+    exp = 'crawl-data/CC-MAIN-2017-13/segments/1490218187144.60/warc/'\
+          'CC-MAIN-20170322212947-00594-ip-10-233-31-227.ec2.internal.warc.gz'
+    assert index['filename'] == exp
+    assert index2['filename'] == exp
 
 
 def test_run_odd_workers():
@@ -91,6 +92,7 @@ def test_run_opt_workers():
     index2 = queue.get_nowait()
     assert index is not None
     assert index2 is not None
-    assert int(index['status']) == 200
-    assert index['digest'] == 'WPTH3FM5VR7UGLA5PZS5L5YI22TNIKXG'
-    assert index2['digest'] == 'WPTH3FM5VR7UGLA5PZS5L5YI22TNIKXG'
+    exp = 'crawl-data/CC-MAIN-2017-13/segments/1490218187144.60/warc/'\
+          'CC-MAIN-20170322212947-00594-ip-10-233-31-227.ec2.internal.warc.gz'
+    assert index['filename'] == exp
+    assert index2['filename'] == exp


### PR DESCRIPTION
Memory used per index is now 288 bytes instead of 480 bytes. So 60% of the previous size.