### PR TITLE
Add API routes to retrieve document (top) probabilities

### DIFF
--- a/tests/utils/test_db_utils.py
+++ b/tests/utils/test_db_utils.py
@@ -231,7 +231,6 @@ def test_get_index_probabilities():
         'education': 0,
         'collaboration': 0,
         'transportation': 0,
-        'other': 0
     }
     assert db_utils.get_index_probabilities(index) == expected
 
@@ -248,7 +247,6 @@ def test_get_index_probabilities():
         'education': 0,
         'collaboration': 0,
         'transportation': 0,
-        'other': 0
     }
     expected = [probabilities, probabilities]
     assert db_utils.get_indices_probabilities(indices) == expected
@@ -271,7 +269,6 @@ def test_store_index_probabilities_full():
         'education': 0.15,
         'collaboration': 0.16,
         'transportation': 0.17,
-        'other': 0.19
     }
     assert db_utils.store_index_probabilities(digest, probabilities)
     assert db_utils.get_index_probabilities(digest) == probabilities
@@ -295,7 +292,6 @@ def test_store_index_probabilities_with_update():
         'education': 0,
         'collaboration': 0,
         'transportation': 0,
-        'other': 0
     }
     assert db_utils.store_index_probabilities(index, probabilities)
     assert db_utils.store_index_probabilities(index, update)
@@ -313,7 +309,6 @@ def test_store_indices_probabilities():
         'education': 0,
         'collaboration': 0,
         'transportation': 0,
-        'other': 0
     }
     expected = [values, values]
     assert db_utils.store_indices_probabilities(indices, expected)

--- a/urbansearch/server/data.py
+++ b/urbansearch/server/data.py
@@ -1,7 +1,7 @@
 import csv
 import io
 import time
-from flask import Blueprint, send_file, request
+from flask import Blueprint, send_file, request, jsonify
 
 import config
 from urbansearch.utils import db_utils
@@ -72,3 +72,27 @@ def _export_all_with_threshold(threshold):
     header.remove('other')
     header.append('filtered_total')
     return _gen_csv(header, data, 'threshold{}'.format(threshold.replace('.', '_')))
+
+
+@data_api.route('/top_probability/<string:digest>', methods=['GET'])
+def top_probability(digest):
+    """
+    Retrieves the top probability for a given document.
+
+    :param digest: The unique identifier of a document
+    :return: A category:probability JSON object
+    """
+    probabilities = db_utils.get_index_probabilities(digest)
+    max_cat = max(probabilities, key=probabilities.get)
+    return jsonify({max_cat: probabilities[max_cat]})
+
+
+@data_api.route('/probabilities/<string:digest>', methods=['GET'])
+def probabilities(digest):
+    """
+    Retrieves the category probabilities for a given document.
+    :param digest: the unique identifier of the document
+    :return: a JSON object containing all category:probability pairs
+    """
+    probabilities = db_utils.get_index_probabilities(digest)
+    return jsonify(probabilities)

--- a/urbansearch/utils/db_utils.py
+++ b/urbansearch/utils/db_utils.py
@@ -10,6 +10,7 @@ CATEGORIES = config.get('score', 'categories')
 CAT_NO_OTHER = list(CATEGORIES)
 CAT_NO_OTHER.remove('other')
 DEFAULT_CAT_DICT = dict.fromkeys(CATEGORIES, 0)
+DEFAULT_CAT_DICT_NO_OTHER = dict.fromkeys(CAT_NO_OTHER, 0)
 DEFAULT_SCORE_DICT = {'total': 0, **DEFAULT_CAT_DICT}
 RELATES_TO = config.get('neo4j', 'relates_to_name')
 OCCURS_IN = config.get('neo4j', 'occurs_in_name')
@@ -269,7 +270,7 @@ def _store_index_probabilities_query(digest, probabilities):
     # Default probabilities (0) are used if none are provided
     # Returns a query, params tuple
     if not probabilities:
-        probabilities = DEFAULT_CAT_DICT
+        probabilities = DEFAULT_CAT_DICT_NO_OTHER
 
     query = '''
         MATCH (i:Index {{ digest: $digest }})
@@ -291,7 +292,6 @@ def store_index_probabilities(digest, probabilities=None):
     - education
     - collaboration
     - transportation
-    - other
 
     :param digest: The unique identifier of the index
     :param probabilities: A dictionary of topic:probability pairs
@@ -473,7 +473,7 @@ def _get_index_probabilities_query(digest):
     query = '''
         MATCH (i:Index {{ digest: $digest }})
         RETURN {}
-    '''.format(', '.join('i.{0} AS {0}'.format(p) for p in CATEGORIES))
+    '''.format(', '.join('i.{0} AS {0}'.format(p) for p in CAT_NO_OTHER))
     return query, {'digest': digest}
 
 


### PR DESCRIPTION
```GET /api/v1/data/top_probability/<digest>
{
  "collaboration": 0.36773660801684827
}

GET /api/v1/data/probabilities/<digest>
{
  "collaboration": 0.36773660801684827, 
  "commuting": 0.08450070057224988, 
  "education": 0.08710570547140625, 
  "leisure": 0.0847440561835373, 
  "residential_mobility": 0.13243811253934482, 
  "shopping": 0.05888968118036202, 
  "transportation": 0.1845851360362514
}