### PR TITLE
Add API route for retrieving a list of documents for ic rel

### DIFF
--- a/urbansearch/server/documents.py
+++ b/urbansearch/server/documents.py
@@ -17,6 +17,7 @@ NUMBER_OF_DOCUMENTS_PER_WORKER = config.get('api', 'num_of_docs')
 def get_categorie(document):
     ct.category_with_threshold(ct.probability_per_category(document), 0.3)
 
+
 def random_worker():
     return randint(0, NUMBER_OF_WORKERS - 1)
 
@@ -27,8 +28,6 @@ def random_file():
 
 @documents_api.route('/', methods=['GET'], strict_slashes=False)
 def get_random():
-    """
-    """
     while True:
         try:
             with open(DOCUMENT_PATH.format(random_worker(),

--- a/urbansearch/server/main.py
+++ b/urbansearch/server/main.py
@@ -7,6 +7,7 @@ from urbansearch.server.documents import documents_api
 from urbansearch.server.indices import indices_api
 from urbansearch.server.predict import predict_api
 from urbansearch.server.data import data_api
+from urbansearch.server.relations import relations_api
 
 API_PREFIX = '/api/v1'
 
@@ -56,3 +57,5 @@ class Server(object):
                                     url_prefix=API_PREFIX + '/classifier')
         self.app.register_blueprint(data_api,
                                     url_prefix=API_PREFIX + '/data')
+        self.app.register_blueprint(relations_api,
+                                    url_prefix=API_PREFIX + '/relations')

--- a/urbansearch/server/relations.py
+++ b/urbansearch/server/relations.py
@@ -1,0 +1,17 @@
+from flask import Blueprint, jsonify, request
+
+from urbansearch.utils import db_utils
+
+relations_api = Blueprint('relations_api', __name__)
+
+
+@relations_api.route('/document_info', methods=['GET'], strict_slashes=False)
+def all_for_ic_rel():
+    if 'city_a' not in request.args or 'city_b' not in request.args:
+        return jsonify(status=400, error='No city pair given')
+
+    city_a = request.args.get('city_a')
+    city_b = request.args.get('city_b')
+    documents = db_utils.get_related_documents(city_a, city_b)
+
+    return jsonify(status=200, documents=documents)


### PR DESCRIPTION
```
GET /api/v1/relations/document_info?city_a=<name city A>&city_b=<name city B>
{
  "documents": [
    {
      "categories": {
        "residential_mobility": 0.7731903387865949
      }, 
      "digest": "digest211740"
    }, 
    {
      "categories": {
        "residential_mobility": 0.5840020880440003
      }, 
      "digest": "digest211558"
    }, 
    {
      "categories": {
        "residential_mobility": 0.5087776527481606
      }, 
      "digest": "digest209036"
    }, 
    {
      "categories": {
        "other": 0
      }, 
      "digest": "digest208234"
    }
  ]
}
```